### PR TITLE
A pull request

### DIFF
--- a/build/Vessel.js
+++ b/build/Vessel.js
@@ -1,4 +1,4 @@
-//Vessel.js library, built 2018-05-06 09:34:31.491148
+//Vessel.js library, built 2018-05-06 21:55:03.738395
 /*
 Import like this in HTML:
 <script src="Vessel.js"></script>
@@ -139,7 +139,7 @@ function bilinearCoeffs(x1, x2, y1, y2, z00, z01, z10, z11) {
 	let Y = (y2-y1);
 	
 	if (X===0 || Y=== 0) {
-		console.warn("bilinearCoeffs: Zero base area. Setting coefficients to zero.");
+		//console.warn("bilinearCoeffs: Zero base area. Setting coefficients to zero.");
 		return [0,0,0,0];
 	}
 	
@@ -245,8 +245,8 @@ function combineAreas(array) {
 		xc /= A;
 		yc /= A;
 	} else {
-		console.warn("Zero area combination.");
-		console.trace();
+		//console.warn("Zero area combination.");
+		//console.trace();
 		xc /= L;
 		yc /= L;
 	}
@@ -728,14 +728,14 @@ Object.assign(Ship.prototype, {
 		);
 		
 		//DEBUG
-		console.log(components);
+		//console.log(components);
 
 		for (let o of Object.values(this.derivedObjects)) {
 			components.push(o.getWeight(shipState));
 		}
 
 		var W = combineWeights(components);
-		console.info("Calculated weight object: ", W);
+		//console.info("Calculated weight object: ", W);
 		return W;
 	},
 	calculateDraft: function(shipState, epsilon=0.001, rho=1025) {
@@ -783,7 +783,7 @@ Object.assign(Ship.prototype, {
 			if (mass <= tkMass) { // if yes, subtract mass
 				shipState.objectCache[tkId].state.fullness -= mass/(this.derivedObjects[tkId].baseObject.weightInformation.volumeCapacity * this.derivedObjects[tkId].baseObject.weightInformation.contentDensity);
 				mass = 0;
-				console.log("Vessel is sailing on fuel from " + tkId + ".");
+				//console.log("Vessel is sailing on fuel from " + tkId + ".");
 			} else { // if not, make tank empty
 				mass -= tkMass;
 				shipState.objectCache[tkId].state.fullness = 0;
@@ -857,7 +857,7 @@ Object.assign(Structure.prototype, {
 		
 		return spec;
 	},
-	//Alejandro is working on a more proper calculation of this
+	//This is all dummy calculations
 	getWeight: function(designState) {
 		let components = [];
 		//Hull
@@ -899,7 +899,7 @@ Object.assign(Structure.prototype, {
 		}
 		
 		let output = combineWeights(components);
-		console.info("Total structural weight: ", output);
+		//console.info("Total structural weight: ", output);
 		return output;
 	}
 });//@EliasHasle
@@ -949,7 +949,7 @@ Object.assign(Hull.prototype, {
 		parsons.mass *= 1000; //ad hoc conversion to kg, because the example K value is aimed at ending with tonnes.
 		
 		let output = parsons;
-		console.info("Hull weight:", output);
+		//console.info("Hull weight:", output);
 		return output;
 	},
 	/*
@@ -969,12 +969,12 @@ Object.assign(Hull.prototype, {
 		let tab = this.halfBreadths.table;
 
 		if (zr<wls[0]) {
-				console.warn("getWaterLine: z below lowest defined waterline. Defaulting to all zero offsets.");
+				//console.warn("getWaterLine: z below lowest defined waterline. Defaulting to all zero offsets.");
 				return new Array(sts.length).fill(0);
 		} else {
 			let a, mu;
 			if (zr>wls[wls.length-1]) {
-				console.warn("getWaterLine: z above highest defined waterline. Proceeding with highest data entries.");
+				//console.warn("getWaterLine: z above highest defined waterline. Proceeding with highest data entries.");
 				a = wls.length-2; //if this level is defined...
 				mu=1;
 				//wl = tab[a].slice();
@@ -1292,7 +1292,7 @@ Object.assign(Hull.prototype, {
 					patchColumnCalculation(sts[j], sts[j+1], prev.z, z, prwl[j], wl[j], prwl[j+1], wl[j+1]);
 				calculations.push(star);
 			}
-			console.log(calculations); //DEBUG
+			//console.log(calculations); //DEBUG
 			let C = combineVolumes(calculations);
 			//Cv of slice. Note that switching of yz must
 			//be done before combining with previous level
@@ -1348,8 +1348,8 @@ Object.assign(Hull.prototype, {
 			//Find highest data waterline below or at water level:
 			let {index, mu} = bisectionSearch(wls, T);
 			
-			console.info("Highest data waterline below or at water level: " + index);
-			console.log(this.levels);
+			//console.info("Highest data waterline below or at water level: " + index);
+			//console.log(this.levels);
 			let lc;
 			if (mu===0) lc = this.levels[index];
 			else lc = levelCalculation(this, T, this.levels[index]);
@@ -1395,11 +1395,11 @@ Object.assign(Hull.prototype, {
 		while (b-a>epsilon) {
 			t = 0.5*(a+b);
 			let V = this.calculateAttributesAtDraft(t)["Vs"];
-			console.log(V); //DEBUG
+			//console.log(V); //DEBUG
 			if (V>VT) b = t;
 			else a = t;
 		}
-		console.info("Calculated draft: %.2f", t);
+		//console.info("Calculated draft: %.2f", t);
 		return t;
 	}
 });//@EliasHasle
@@ -1468,7 +1468,7 @@ Object.assign(BaseObject.prototype, {
 				cg.push(c);
 			}
 		} else if (wi.cg !== undefined) {
-			console.log("BaseObject.getWeight: Using specified cg.");
+			//console.log("BaseObject.getWeight: Using specified cg.");
 			cg = wi.cg;
 		} else {
 			console.warn("BaseObject.getWeight: No cg or fullnessCGMapping supplied. Defaults to center of bounding box.");
@@ -1544,9 +1544,9 @@ Object.assign(DerivedObject.prototype, {
 });//@EliasHasle
 
 /*
-The object state assignments could/should also have a baseByGroup. A group of baseObjects could for instance be a category including all tanks that carry a given compound, regardless of their size and shape. Maybe "group" is not a good name for something that can be set freely. Maybe "label" or "tag" or something else. The same goes for derivedByGroup.
+The object state assignments can now target baseByGroup. A group of baseObjects can for instance be a category including all tanks that carry a given compound, regardless of their size and shape. Maybe "group" is not a good name for something that can be set freely. Maybe "label" or "tag" or something else. The same goes for derivedByGroup.
 
-With this, there would be five types of assignments:
+Now there are five types of assignments in this class:
 common: All objects.
 baseByGroup: Applies to every object that has its base object's property "group" set to the given name.
 baseByID: Applies to all objects that have base object consistent with the given ID:
@@ -1554,6 +1554,8 @@ derivedByGroup: Applies to every object that has its property "group" set to the
 derivedByID: Applies only to the object with given ID.
 
 Assignments of subsequent types override assignments of previous types.
+
+Note that the foundation for object state is laid in baseObject.baseState and derivedObject.referenceState. The abovementioned assignments apply only as overrides. They do not introduce new properties.
 */
 
 /*
@@ -1594,28 +1596,38 @@ Object.assign(ShipState.prototype, {
 	clone: function() {
 		return new ShipState(this.getSpecification());
 	},
+	//Method to get the state of a DerivedObject
 	getObjectState: function(o) {
 		if (this.objectCache[o.id] !== undefined) {
 			let c = this.objectCache[o.id];
 			if (c.thisStateVer === this.version
 				/*&& c.baseStateVer === o.baseObject.baseStateVersion
 				&& c.refStateVer === o.referenceStateVersion*/) {
-				console.log("ShipState.getObjectState: Using cache.");
+				//console.log("ShipState.getObjectState: Using cache.");
 				return c.state;	
 			}				
 		}
-		console.log("ShipState.getObjectState: Not using cache.");
+		//console.log("ShipState.getObjectState: Not using cache.");
 		
+		//Build the state in multiple steps,
+		//such that the later steps override
+		//the earlier ones when in conflict.
+		//The two first steps lay the foundation.
 		let state = {};
+		//1.
 		Object.assign(state, o.baseObject.baseState);
+		//2.
 		Object.assign(state, o.referenceState);
+		//The next steps are different, because there,
+		//only existing properties will be updated.
 		let oo = this.objectOverrides;
-		let sources = [oo.common, oo.baseByID[o.baseObject.id], oo.derivedByGroup[o.affiliations.group], oo.derivedByID[o.id]];
+		//3., 4., 5., 6.
+		let sources = [oo.common, oo.baseByGroup[o.baseObject.group], oo.baseByID[o.baseObject.id], oo.derivedByGroup[o.affiliations.group], oo.derivedByID[o.id]];
 		for (let i = 0; i < sources.length; i++) {
 			let s = sources[i];
 			if (!s) continue;
-			let sk = Object.keys(s);
-			for (let k of sk) {
+			//let sk = Object.keys(s);
+			for (let k in/*of*/ s) {//(sk) {
 				//Override existing properties only:
 				if (state[k] !== undefined) {
 					state[k] = s[k];
@@ -1623,6 +1635,8 @@ Object.assign(ShipState.prototype, {
 			}
 		}
 		
+		//Cache the result, conditioned on the ShipState version
+		//(not good, should restrict the dependency more)
 		this.objectCache[o.id] = {
 			thisStateVer: this.version,
 			/*baseStateVer: o.baseObject.baseStateVersion,
@@ -1637,7 +1651,7 @@ Object.assign(ShipState.prototype, {
 		return this.getObjectState(o)[k];
 		//I have commented out a compact, but not very efficient, implementation of Alejandro's pattern, that does not fit too well with my caching solution.
 /*		let oo = this.objectOverrides;
-		let sources = [oo.derivedByID[o.id], oo.derivedByGroup[o.affiliations.group], oo.baseByID[o.baseObject.id], oo.common, o.getReferenceState(), o.baseObject.getBaseState()].filter(e=>!!e);
+		let sources = [oo.derivedByID[o.id], oo.derivedByGroup[o.affiliations.group], oo.baseByID[o.baseObject.id], oo.baseByGroup[o.baseObject.group], oo.common, o.getReferenceState(), o.baseObject.getBaseState()].filter(e=>!!e);
 		for (let i = 0; i < sources.length; i++) {
 			if (sources[i][k] !== undefined) return sources[i][k];
 		}
@@ -1652,7 +1666,7 @@ Object.assign(ShipState.prototype, {
 				//Named overrides because only existing corresponding properties will be set
 				objectOverrides: {
 					commmon: {},
-					//baseByGroup: {},
+					baseByGroup: {},
 					baseByID: {},
 					derivedByGroup: {},
 					derivedByID: {}
@@ -1666,6 +1680,7 @@ Object.assign(ShipState.prototype, {
 		let oo = this.objectOverrides;
 		let soo = spec.objectOverrides || {};
 		oo.common = soo.common || {};
+		oo.baseByGroup = soo.baseByGroup || {};
 		oo.baseByID = soo.baseByID || {};
 		oo.derivedByGroup = soo.derivedByGroup || {};
 		oo.derivedByID = soo.derivedByID || {};
@@ -1679,8 +1694,8 @@ Object.assign(ShipState.prototype, {
 		let oo = this.objectOverrides;
 		let soo = spec.objectOverrides || {};
 		Object.assign(oo.common, soo.common);
-		let sources = [soo.baseByID, soo.derivedByGroup, soo.derivedByID];
-		let targets = [oo.baseByID, oo.derivedByGroup, oo.derivedByID];
+		let sources = [soo.baseByGroup, soo.baseByID, soo.derivedByGroup, soo.derivedByID];
+		let targets = [oo.baseByGroup, oo.baseByID, oo.derivedByGroup, oo.derivedByID];
 		for (let i = 0; i < sources.length; i++) {
 			if (!sources[i]) continue;
 			let sk = Object.keys(sources[i]);
@@ -1712,8 +1727,8 @@ Object.assign(ShipState.prototype, {
 			}
 		}
 
-		sources = [soo.common, soo.baseByID, soo.derivedByGroup, soo.derivedByID];
-		targets = [oo.common, oo.baseByID, oo.derivedByGroup, oo.derivedByID];
+		sources = [soo.common, soo.baseByGroup, soo.baseByID, soo.derivedByGroup, soo.derivedByID];
+		targets = [oo.common, oo.baseByGroup, oo.baseByID, oo.derivedByGroup, oo.derivedByID];
 		
 		for (let i = 0; i < sources.length; i++) {
 			if (!sources[i]) continue;

--- a/examples/Many_ships_Jensen_defective.html
+++ b/examples/Many_ships_Jensen_defective.html
@@ -1,0 +1,256 @@
+<!--@EliasHasle-->
+<!--
+This is not working very well yet. See notes in ./js/Jensen.js.
+Note that the "fakeState" that is being used here, is made to 
+simulate the presence of a richer ShipState than is currently in use.
+See ShipState_new.js in classes for a start on that development.
+-->
+<html>
+<head>
+	<title>Many ships in Ocean moving according to Jensen's equations</title>
+	<script src="../build/Vessel.js"></script>
+	
+	<script src="js/libs/three.js"></script>
+	<script src="js/libs/STLLoader.js"></script>
+	
+	<script src="js/Ship3D_v2.js"></script>
+	<script src="js/Jensen.js"></script>
+
+	<!-- Upgrading to WaterShader2.js will remove the dependency 
+	on Mirror.js as well as open up possibilities for visualizing approximate water flows around vessels. -->
+	<script src="js/libs/Mirror.js"></script>
+	<script src="js/libs/WaterShader.js"></script>
+	
+	<script src="js/libs/OrbitControls.js"></script>
+	<script src="js/libs/dat.gui.min.js"></script>
+	<script src="js/libs/skybox_from_examples.js"></script>
+	
+	<script src="js/libs/browse_files_Elias_Hasle.js"></script>
+	<script src="js/Patch_interpolation.js"></script>
+	<!--<script src="Moving_bodies_Elias_Hasle.js"></script>-->
+	<script src="js/Playback.js"></script>
+	<script src="js/Configurable_ocean.js"></script>
+	<!--<script src="keyboard_arrow_input_Elias_Hasle.js"></script>-->
+</head>
+
+<body>
+<script>
+"use strict";
+
+//Globals
+var renderer, camera, controls, gui, stats;
+var scene, zUpCont, playback, ships, ocean;
+var frfsNeedUpdate = true;
+
+(function main() {
+	//Renderer setup
+	//document.body.style = "overflow: hidden;";
+	document.body.style.overflow = "hidden";
+	var container = document.createElement("div");
+	//container.style = "position: absolute; top: 0; left: 0;"
+	Object.assign(container.style, {
+		position: "absolute",
+		top: 0,
+		left: 0,
+		width: "100vw",
+		height: "100vh"
+	});
+	document.body.appendChild(container);
+	renderer = new THREE.WebGLRenderer({antialias: true});
+	//renderer.setSize(window.innerWidth, window.innerHeight);
+	renderer.setClearColor(0x99aadd);
+	container.appendChild(renderer.domElement);
+	//stats = new Stats();
+	//document.body.appendChild(stats.domElement);
+
+	//GUI setup (comment out to remove gui)
+	gui = new dat.GUI();
+	
+	playback = new Playback({parentGUI: gui});
+	
+	//Scene setup:
+	scene = new THREE.Scene();
+	let sun = new THREE.DirectionalLight(0xffffff,2);
+	sun.position.set(-512, 246, 128);
+	scene.add(sun);
+	
+	//Ocean size
+	let oSize = 2048;
+	
+	scene.add(new Skybox(oSize));
+	
+	//Use Z up from now on:
+	THREE.Object3D.DefaultUp.set(0,0,1);
+	zUpCont = new THREE.Group();
+	zUpCont.rotation.x = -0.5*Math.PI;
+	scene.add(zUpCont);
+	
+	//Camera setup
+	camera = new THREE.PerspectiveCamera(26, window.innerWidth/window.innerHeight, 1, 1000000);
+	let onResize = function() {
+		let w = container.clientWidth;
+		let h = container.clientHeight;
+		renderer.setSize(w,h);
+		camera.aspect = w/h;
+		camera.updateProjectionMatrix();
+		//camera.aspect = window.innerWidth / window.innerHeight;
+		//camera.updateProjectionMatrix();
+		//renderer.setSize(window.innerWidth, window.innerHeight);
+	};
+	window.addEventListener('resize', onResize, false);
+	onResize();
+	camera.position.set(oSize*0.45, oSize*0.7, oSize*0.1);
+	camera.lookAt(zUpCont.position);
+	zUpCont.add(camera);
+	
+	controls = new THREE.OrbitControls(camera, renderer.domElement);
+	//controls.minDistance = 0;
+	//controls.maxDistance = 0.5*oSize;
+	//controls.enablePan = false;
+	//controls.maxPolarAngle = 0.5*Math.PI-0.1;
+	//controls.minPolarAngle = 0.1;
+
+	//zUpCont.add(new THREE.AxisHelper(1000));
+	zUpCont.add(new THREE.HemisphereLight(0xccccff, 0x666688, 1));
+	
+	ocean = new Ocean({//parentGUI: gui,
+						sunDir: sun.position.clone().normalize(),
+						size: oSize, segments: 127});
+	playback.add(ocean);
+	zUpCont.add(ocean);
+	
+	let designs = ["PX121","blockCase","prismaticHull","trapezoidPrismHull"];
+	
+	ships = new THREE.Group();
+	zUpCont.add(ships);
+	
+	function addShip() {
+		let design = designs[Math.floor(Math.random()*designs.length)];
+		Vessel.loadShip("data/ship_specifications/"+design+".json", function (ship) {
+			
+			let ship3D = new Ship3D(ship, {
+				stlPath: "data/STL files",
+				upperColor: 0x33aa33,
+				lowerColor: 0xaa3333,
+				hullOpacity: 1,
+				deckOpacity: 1,
+				objectOpacity: 1
+			});
+			ships.add(ship3D);
+			ship3D.position.x = (Math.random()-0.5)*oSize;
+			ship3D.position.y = (Math.random()-0.5)*oSize;
+			ship3D.rotation.z = (4*Math.random()-2)*Math.PI;
+			
+			ship3D.fakeState = {motion:{}};
+			Object.defineProperties(ship3D.fakeState.motion, {
+				x: {
+					get: ()=>ship3D.position.x,
+					set: function (val) {
+						ship3D.position.x = val;
+						return true;
+					}
+				},
+				y: {
+					get: ()=>ship3D.position.y,
+					set: function (val) {
+						ship3D.position.y = val;
+						return true;
+					}
+				},
+				heading: {
+					get: ()=>ship3D.rotation.z,
+					set: function (val) {
+						ship3D.rotation.z = val;
+						return true;
+					}
+				}
+			});
+			
+			ship3D.j = new Jensen(w,ship3D.ship,ship3D.fakeState);
+			playback.add(function(t, dt) {
+				ship3D.j.update(t);
+				ship3D.heave = ship3D.j.heave;
+				ship3D.pitch = ship3D.j.pitch;
+				ship3D.roll = ship3D.j.roll;
+			});
+		});
+	}
+	
+	/*bodies = new MultiBodies({parentGUI: gui,
+							side: oSize/4,
+							clickable: true,
+							ocean: ocean});
+	playback.add(bodies);
+	zUpCont.add(bodies);*/
+	
+	//Initial configuration:
+	//let w = ocean.addCosineWave({A:5, T:11, theta: 1});
+	//if (w.conf) w.conf.close();
+	let w = new DirectionalCosine({A:5, T:11, theta: 0});
+	ocean.waves.push(w);
+	let p = new Proxy(w, {
+		set: function(target,property,value) {
+			target[property] = value;
+			if (property==="T")
+				p.updateWavelength();
+			frfsNeedUpdate = true;
+			return true;
+		}
+	});
+	let wconf = gui.addFolder("Wave");
+	wconf.open();
+	wconf.add(p,"A",0,10);
+	wconf.add(p,"T",3,30);
+	/*wconf.add({f:function() {
+		p.updateWavelength();
+		wconf.updateDisplay();
+	}}, "f").name("Auto wavelength");
+	wconf.add(p, "L",6.0,700.0, 0.5);*/
+	wconf.add(p, "theta", -Math.PI, Math.PI, 0.01);
+	wconf.add(p, "phi", -Math.PI, Math.PI, 0.01);
+	
+	let o = {numShips:1};
+	function correctNum(value) {
+		let n = ships.children.length;
+		if (n < value) {
+			for (let i = 0; n+i < value; i++) {
+				addShip();
+			}
+		} else if (n > value) {
+			while (n > value) {
+				ships.remove(ships.children[n-1]);
+				n--;
+			}
+		}
+	}
+	correctNum(o.numShips);
+	gui.add(o,"numShips",1,200,1).onChange(correctNum);
+	
+	playback.play();
+	
+	requestAnimationFrame(animate);
+})();
+
+function animate(millitime) {
+	if (frfsNeedUpdate = true) {
+		for (let sh3d of ships.children) {
+			sh3d.j.updateFRFs();
+		}
+		frfsNeedUpdate = false;
+	}
+	
+	let playing = playback.update();
+	
+	//Disable this to freeze water when not playing
+	if (!playing) {
+		ocean.water.material.uniforms.time.value += 1/60;
+	}
+		
+	ocean.water.render();
+	
+	renderer.render(scene, camera);
+	requestAnimationFrame(animate);
+}
+</script>
+</body>
+</html>

--- a/examples/Many_ships_in_configurable_ocean.html
+++ b/examples/Many_ships_in_configurable_ocean.html
@@ -1,0 +1,226 @@
+<html>
+<head>
+	<title>Many ships in configurable Ocean</title>
+	<script src="../build/Vessel.js"></script>
+	
+	<script src="js/libs/three.js"></script>
+	<script src="js/libs/STLLoader.js"></script>
+	
+	<script src="js/Ship3D_v2.js"></script>
+
+	<!-- Upgrading to WaterShader2.js will remove the dependency 
+	on Mirror.js as well as open up possibilities for visualizing approximate water flows around vessels. -->
+	<script src="js/libs/Mirror.js"></script>
+	<script src="js/libs/WaterShader.js"></script>
+	
+	<script src="js/libs/OrbitControls.js"></script>
+	<script src="js/libs/dat.gui.min.js"></script>
+	<script src="js/libs/skybox_from_examples.js"></script>
+	
+	<script src="js/libs/browse_files_Elias_Hasle.js"></script>
+	<script src="js/Patch_interpolation.js"></script>
+	<!--<script src="Moving_bodies_Elias_Hasle.js"></script>-->
+	<script src="js/Playback.js"></script>
+	<script src="js/Configurable_ocean.js"></script>
+	<!--<script src="keyboard_arrow_input_Elias_Hasle.js"></script>-->
+</head>
+
+<body>
+<script>
+"use strict";
+
+//Globals
+var renderer, camera, controls, gui, stats;
+var scene, zUpCont, playback, ships, ocean;
+
+(function main() {
+	//Renderer setup
+	//document.body.style = "overflow: hidden;";
+	document.body.style.overflow = "hidden";
+	var container = document.createElement("div");
+	//container.style = "position: absolute; top: 0; left: 0;"
+	Object.assign(container.style, {
+		position: "absolute",
+		top: 0,
+		left: 0,
+		width: "100vw",
+		height: "100vh"
+	});
+	document.body.appendChild(container);
+	renderer = new THREE.WebGLRenderer({antialias: true});
+	//renderer.setSize(window.innerWidth, window.innerHeight);
+	renderer.setClearColor(0x99aadd);
+	container.appendChild(renderer.domElement);
+	//stats = new Stats();
+	//document.body.appendChild(stats.domElement);
+
+	//GUI setup (comment out to remove gui)
+	gui = new dat.GUI();
+	
+	playback = new Playback({parentGUI: gui});
+	
+	//Scene setup:
+	scene = new THREE.Scene();
+	let sun = new THREE.DirectionalLight(0xffffff,2);
+	sun.position.set(-512, 246, 128);
+	scene.add(sun);
+	
+	//Ocean size
+	let oSize = 2048;
+	
+	scene.add(new Skybox(oSize));
+	
+	//Use Z up from now on:
+	THREE.Object3D.DefaultUp.set(0,0,1);
+	zUpCont = new THREE.Group();
+	zUpCont.rotation.x = -0.5*Math.PI;
+	scene.add(zUpCont);
+	
+	//Camera setup
+	camera = new THREE.PerspectiveCamera(26, window.innerWidth/window.innerHeight, 1, 1000000);
+	let onResize = function() {
+		let w = container.clientWidth;
+		let h = container.clientHeight;
+		renderer.setSize(w,h);
+		camera.aspect = w/h;
+		camera.updateProjectionMatrix();
+		//camera.aspect = window.innerWidth / window.innerHeight;
+		//camera.updateProjectionMatrix();
+		//renderer.setSize(window.innerWidth, window.innerHeight);
+	};
+	window.addEventListener('resize', onResize, false);
+	onResize();
+	camera.position.set(oSize*0.45, oSize*0.7, oSize*0.1);
+	camera.lookAt(zUpCont.position);
+	zUpCont.add(camera);
+	
+	controls = new THREE.OrbitControls(camera, renderer.domElement);
+	//controls.minDistance = 0;
+	//controls.maxDistance = 0.5*oSize;
+	//controls.enablePan = false;
+	//controls.maxPolarAngle = 0.5*Math.PI-0.1;
+	//controls.minPolarAngle = 0.1;
+
+	//zUpCont.add(new THREE.AxisHelper(1000));
+	zUpCont.add(new THREE.HemisphereLight(0xccccff, 0x666688, 1));
+	
+	ocean = new Ocean({parentGUI: gui,
+						sunDir: sun.position.clone().normalize(),
+						size: oSize, segments: 127});
+	playback.add(ocean);
+	zUpCont.add(ocean);
+	
+	ships = new THREE.Group();
+	zUpCont.add(ships);
+	
+	function callback(ship) {
+		let ship3D = new Ship3D(ship, {
+			stlPath: "data/STL files",
+			upperColor: 0x33aa33,
+			lowerColor: 0xaa3333,
+			hullOpacity: 1,
+			deckOpacity: 1,
+			objectOpacity: 1
+		});
+		ships.add(ship3D);
+		ship3D.position.x = (Math.random()-0.5)*oSize;
+		ship3D.position.y = (Math.random()-0.5)*oSize;
+		ship3D.rotation.z = (4*Math.random()-2)*Math.PI;
+		
+		//VERY approximate motion (for visualisation only)
+		playback.add(function(t, dt) {
+			//This would be optimization
+			//if (!ship3D.visible) return;
+		
+			let x = ship3D.position.x;
+			let y = ship3D.position.y;
+			let theta = ship3D.rotation.z;
+
+			//Approximate half length and half width
+			let hL = ship3D.ship.structure.hull.attributes.LOA/2;
+			let hW = ship3D.ship.structure.hull.attributes.BOA/2;
+
+			let oCenter = ocean.calculateZ(x,y,t);
+			
+			let xFore = x+hL*Math.cos(theta);
+			let yFore = y+hL*Math.sin(theta);
+			let oFore = ocean.calculateZ(xFore,yFore,t);
+
+			let xAft = x-hL*Math.cos(theta);
+			let yAft = y-hL*Math.sin(theta);
+			let oAft = ocean.calculateZ(xAft,yAft,t);
+
+			let xPortside = x + hW*Math.sin(theta);
+			let yPortside = y - hW*Math.cos(theta);
+			let oPortside = ocean.calculateZ(xPortside,yPortside,t);
+			
+			let xStarboard = x - hW*Math.sin(theta);
+			let yStarboard = y + hW*Math.cos(theta);
+			let oStarboard = ocean.calculateZ(xStarboard,yStarboard,t);
+			
+			ship3D.heave = oCenter;
+			//ship3D.heave = (0.5*oCenter + 0.125*(oPortside+oStarboard) + 0.125*(oFore+oAft));
+			ship3D.pitch = -0.8*Math.atan2(oFore-oAft, 2*hL);
+			ship3D.roll = -0.7*Math.atan2(oPortside-oStarboard, 2*hW);
+		});
+	}
+	
+	let designs = ["PX121","blockCase","prismaticHull","trapezoidPrismHull"];
+	function addShip() {
+		let design = designs[0];//designs[Math.floor(Math.random()*designs.length)];
+		Vessel.loadShip("data/ship_specifications/"+design+".json", callback);
+	}
+	
+	/*bodies = new MultiBodies({parentGUI: gui,
+							side: oSize/4,
+							clickable: true,
+							ocean: ocean});
+	playback.add(bodies);
+	zUpCont.add(bodies);*/
+	
+	//Initial configuration:
+	let w = ocean.addCosineWave({A:5, T:11, theta: 1});
+	if (ocean.cosConf) ocean.cosConf.close();
+	
+	let o = {numShips:5};
+	function correctNum(value) {
+		let n = ships.children.length;
+		if (n < value) {
+			for (let i = 0; n+i < value; i++) {
+				addShip();
+			}
+		} else if (n > value) {
+			while (n > value) {
+				ships.remove(ships.children[n-1]);
+				n--;
+			}
+		}
+	}
+	correctNum(o.numShips);
+	gui.add(o,"numShips",1,100).onChange(correctNum);
+	gui.add({addFromFile: function() {
+		o.numShips++;
+		Vessel.browseShip(callback);
+	}}, "addFromFile");
+	
+	playback.play();
+	
+	requestAnimationFrame(animate);
+})();
+
+function animate(millitime) {	
+	let playing = playback.update();
+	
+	//Disable this to freeze water when not playing
+	if (!playing) {
+		ocean.water.material.uniforms.time.value += 1/60;
+	}
+		
+	ocean.water.render();
+	
+	renderer.render(scene, camera);
+	requestAnimationFrame(animate);
+}
+</script>
+</body>
+</html>

--- a/examples/Many_ships_in_still_water.html
+++ b/examples/Many_ships_in_still_water.html
@@ -1,0 +1,178 @@
+<html>
+<head>
+	<title>Many ships in still water</title>
+	<script src="../build/Vessel.js"></script>
+	
+	<script src="js/libs/three.js"></script>
+	<script src="js/libs/STLLoader.js"></script>
+	
+	<script src="js/Ship3D_v2.js"></script>
+
+	<!-- Upgrading to WaterShader2.js will remove the dependency 
+	on Mirror.js as well as open up possibilities for visualizing approximate water flows around vessels. -->
+	<script src="js/libs/Mirror.js"></script>
+	<script src="js/libs/WaterShader.js"></script>
+	
+	<script src="js/libs/OrbitControls.js"></script>
+	<script src="js/libs/dat.gui.min.js"></script>
+	<script src="js/libs/skybox_from_examples.js"></script>
+	
+	<script src="js/libs/browse_files_Elias_Hasle.js"></script>
+	<script src="js/Patch_interpolation.js"></script>
+	<!--<script src="Moving_bodies_Elias_Hasle.js"></script>-->
+	<script src="js/Playback.js"></script>
+	<script src="js/Configurable_ocean.js"></script>
+	<!--<script src="keyboard_arrow_input_Elias_Hasle.js"></script>-->
+</head>
+
+<body>
+<script>
+"use strict";
+
+//Globals
+var renderer, camera, controls, gui, stats;
+var scene, zUpCont, playback, ships, ocean;
+
+(function main() {
+	//Renderer setup
+	//document.body.style = "overflow: hidden;";
+	document.body.style.overflow = "hidden";
+	var container = document.createElement("div");
+	//container.style = "position: absolute; top: 0; left: 0;"
+	Object.assign(container.style, {
+		position: "absolute",
+		top: 0,
+		left: 0,
+		width: "100vw",
+		height: "100vh"
+	});
+	document.body.appendChild(container);
+	renderer = new THREE.WebGLRenderer({antialias: true});
+	//renderer.setSize(window.innerWidth, window.innerHeight);
+	renderer.setClearColor(0x99aadd);
+	container.appendChild(renderer.domElement);
+	//stats = new Stats();
+	//document.body.appendChild(stats.domElement);
+
+	//GUI setup (comment out to remove gui)
+	gui = new dat.GUI();
+	
+	playback = new Playback({parentGUI: gui});
+	
+	//Scene setup:
+	scene = new THREE.Scene();
+	let sun = new THREE.DirectionalLight(0xffffff,2);
+	sun.position.set(-512, 246, 128);
+	scene.add(sun);
+	
+	//Ocean size
+	let oSize = 2048;
+	
+	scene.add(new Skybox(oSize));
+	
+	//Use Z up from now on:
+	THREE.Object3D.DefaultUp.set(0,0,1);
+	zUpCont = new THREE.Group();
+	zUpCont.rotation.x = -0.5*Math.PI;
+	scene.add(zUpCont);
+	
+	//Camera setup
+	camera = new THREE.PerspectiveCamera(26, window.innerWidth/window.innerHeight, 1, 1000000);
+	let onResize = function() {
+		let w = container.clientWidth;
+		let h = container.clientHeight;
+		renderer.setSize(w,h);
+		camera.aspect = w/h;
+		camera.updateProjectionMatrix();
+		//camera.aspect = window.innerWidth / window.innerHeight;
+		//camera.updateProjectionMatrix();
+		//renderer.setSize(window.innerWidth, window.innerHeight);
+	};
+	window.addEventListener('resize', onResize, false);
+	onResize();
+	camera.position.set(oSize*0.45, oSize*0.7, oSize*0.1);
+	camera.lookAt(zUpCont.position);
+	zUpCont.add(camera);
+	
+	controls = new THREE.OrbitControls(camera, renderer.domElement);
+	//controls.minDistance = 0;
+	//controls.maxDistance = 0.5*oSize;
+	//controls.enablePan = false;
+	//controls.maxPolarAngle = 0.5*Math.PI-0.1;
+	//controls.minPolarAngle = 0.1;
+
+	//zUpCont.add(new THREE.AxisHelper(1000));
+	zUpCont.add(new THREE.HemisphereLight(0xccccff, 0x666688, 1));
+	
+	ocean = new Ocean({//parentGUI: gui,
+						sunDir: sun.position.clone().normalize(),
+						size: oSize, segments: 127});
+	playback.add(ocean);
+	zUpCont.add(ocean);
+	
+	ships = new THREE.Group();
+	zUpCont.add(ships);
+	
+	function callback(ship) {
+		let ship3D = new Ship3D(ship, {
+			stlPath: "data/STL files",
+			upperColor: 0x33aa33,
+			lowerColor: 0xaa3333,
+			hullOpacity: 1,
+			deckOpacity: 1,
+			objectOpacity: 1
+		});
+		ships.add(ship3D);
+		ship3D.position.x = (Math.random()-0.5)*oSize;
+		ship3D.position.y = (Math.random()-0.5)*oSize;
+		ship3D.rotation.z = (4*Math.random()-2)*Math.PI;
+	}
+	
+	let designs = ["PX121","blockCase","prismaticHull","trapezoidPrismHull"];
+	function addShip() {
+		let design = designs[0];//designs[Math.floor(Math.random()*designs.length)];
+		Vessel.loadShip("data/ship_specifications/"+design+".json", callback);
+	}
+	
+	let o = {numShips:5};
+	function correctNum(value) {
+		let n = ships.children.length;
+		if (n < value) {
+			for (let i = 0; n+i < value; i++) {
+				addShip();
+			}
+		} else if (n > value) {
+			while (n > value) {
+				ships.remove(ships.children[n-1]);
+				n--;
+			}
+		}
+	}
+	correctNum(o.numShips);
+	gui.add(o,"numShips",1,100).onChange(correctNum);
+	gui.add({addFromFile: function() {
+		o.numShips++;
+		Vessel.browseShip(callback);
+	}}, "addFromFile");
+	
+	playback.play();
+	
+	requestAnimationFrame(animate);
+})();
+
+function animate(millitime) {	
+	let playing = playback.update();
+	
+	//Disable this to freeze water when not playing
+	if (!playing) {
+		ocean.water.material.uniforms.time.value += 1/60;
+	}
+		
+	ocean.water.render();
+	
+	renderer.render(scene, camera);
+	requestAnimationFrame(animate);
+}
+</script>
+</body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,7 +1,7 @@
 <!doctype html>
 <html>
 <head>
-<title>shipjs examples</title>
+<title>VesselJS examples</title>
 
 <style>
 dl {

--- a/examples/index.html
+++ b/examples/index.html
@@ -25,9 +25,12 @@ dd {
 <h1>Examples</h1>
 <p>Below are some examples of how the library can be used, along with other libraries and custom scripts.</p>
 <dl>
-<dt><a href="Ship_in_configurable_ocean.html">Ship_in_configurable_ocean.html</a></dt> <dd>A 3D ship made from a ship specification, moving with waves in a configurable ocean. Note that the motion is not at all physically correct. </dd>
-<dt><a href="Ship_in_Ocean_heave_only.html">Ship_in_Ocean_heave_only.html</a></dt> <dd>Simpler version of the above demo.</dd>
 <dt><a href="Ship_in_Ocean_still_water.html">Ship_in_Ocean_still_water.html</a></dt> <dd>Even simpler version.</dd>
+<dt><a href="Ship_in_Ocean_heave_only.html">Ship_in_Ocean_heave_only.html</a></dt> <dd>Simpler version of the above demo.</dd>
+<dt><a href="Ship_in_configurable_ocean.html">Ship_in_configurable_ocean.html</a></dt> <dd>A 3D ship made from a ship specification, moving with waves in a configurable ocean. Note that the motion is not at all physically correct. </dd>
+<dt><a href="Many_ships_in_still_water.html">Many_ships_in_still_water.html</a></dt> <dd></dd>
+<dt><a href="Many_ships_in_configurable_ocean.html">Many_ships_in_configurable_ocean.html</a></dt> <dd></dd>
+<dt><a href="Many_ships_Jensen_defective.html">Many_ships_Jensen_defective.html</a></dt> <dd>An attempt at showing more realistic motion. This example has unresolved issues.</dd>
 <dt><a href="Ship3D_with_pretty_JSON.html">Ship3D_with_pretty_JSON.html</a></dt> <dd>A 3D visualization of the provided ship specification, along with the specification data in a format with expand and collapse.</dd>
 <dt><a href="Ship3D_test.html">Ship3D_test.html</a></dt> <dd>A fullscreen 3D visualization of an example ship specification (based on Ulstein PX121).</dd>
 <dt><a href="Ship3D_load_state_controls.html">Ship3D_load_state_controls.html</a></dt> <dd>Very simple test of changing tank fullness with a slider to see change of draft.</dd>

--- a/examples/js/Configurable_ocean.js
+++ b/examples/js/Configurable_ocean.js
@@ -52,9 +52,30 @@ function DirectionalCosine(params) {
 	//amplitude
 	if (typeof params.A !== "undefined") this.A = params.A
 	//period
-	if (typeof params.T !== "undefined") this.T = params.T;
+	let T;
+	Object.defineProperty(this, "T", {
+		get: function() {
+			return T;
+		},
+		set: function(newvalue) {
+			T = newvalue;
+			this.omega = 2*Math.PI/T;
+		}
+	});
+	this.T = params.T || 5;
 	//direction
-	if (typeof params.theta !== "undefined") this.theta = params.theta;
+	let theta;
+	Object.defineProperty(this, "theta", {
+		get: function() {
+			return theta;
+		},
+		set: function(newvalue) {
+			theta = newvalue;
+			this.costh = Math.cos(theta);
+			this.sinth = Math.sin(theta);
+		}
+	});
+	this.theta = params.theta || 0;
 	//phase shift
 	if (typeof params.phi !== "undefined") this.phi = params.phi;
 	
@@ -62,21 +83,21 @@ function DirectionalCosine(params) {
 }
 Object.assign(DirectionalCosine.prototype, {
 	constructor: DirectionalCosine,
-	//Defaults start
+	//Defaults
 	A: 2.0,
 	T: 5.0,
 	L: 50.0,
 	theta: 0.0,
 	phi: 0.0,
-	//Defaults end
+	//Updates the wave length to the "natural" state
 	updateWavelength: function() {
 		let g = 9.81;
 		this.L = g*this.T*this.T/(2*Math.PI);
 		if (this.conf) this.conf.updateDisplay(); //TEST
 	},
 	calculate: function(x,y,t) {
-			let xm = x*Math.cos(this.theta)-y*Math.sin(this.theta);
-			return this.A*Math.cos(this.phi+(xm/this.L-t/this.T)*2*Math.PI);
+			let xm = x*this.costh-y*this.sinth;
+			return this.A*Math.cos(this.phi+2*Math.PI*(xm/this.L)-this.omega*t);
 	}
 });
 
@@ -121,29 +142,44 @@ function Ocean(params) {
 	The WaterShader is from the THREE examples.
 	The mirror effect does not account for geometry, and there is no self-mirroring. But it mostly looks OK anyway. On tall waves, one can see that the rendered texture is stretched.
 	*/
-	
-	let waterNormals = new THREE.TextureLoader().load( 'textures/waternormals.jpg' );
-	waterNormals.wrapS = waterNormals.wrapT = THREE.RepeatWrapping;
-	this.water = new THREE.Water( renderer, camera, scene, {
-		textureWidth: 512,
-		textureHeight: 512,
-		waterNormals: waterNormals,
-		alpha: 	1.0,
-		sunDirection: params.sunDirection,
-		sunColor: 0xffffff,
-		waterColor: 0x001e0f,
-		distortionScale: 50.0
-	} );
-	
-	THREE.Mesh.call(this, 
-		new THREE.PlaneBufferGeometry(this.size, this.size, this.segments, this.segments),
-		/*new THREE.MeshPhongMaterial({
-			color: 0x041020,
-			side: THREE.DoubleSide,
-			wireframe: true
-		})*/this.water.material);
+	try {
+		let waterNormals = new THREE.TextureLoader().load( 'textures/waternormals.jpg' );
+		waterNormals.wrapS = waterNormals.wrapT = THREE.RepeatWrapping;
+		this.water = new THREE.Water( renderer, camera, scene, {
+			textureWidth: 512,
+			textureHeight: 512,
+			waterNormals: waterNormals,
+			alpha: 	1.0,
+			sunDirection: params.sunDirection,
+			sunColor: 0xffffff,
+			waterColor: 0x001e0f,
+			distortionScale: 50.0
+		} );
+		
+		THREE.Mesh.call(this, 
+			new THREE.PlaneBufferGeometry(this.size, this.size, this.segments, this.segments),
+			/*new THREE.MeshPhongMaterial({
+				color: 0x041020,
+				side: THREE.DoubleSide,
+				wireframe: true
+			})*/this.water.material);
 
-	this.add(this.water);
+		this.add(this.water);
+	} catch (e) {
+		THREE.Mesh.call(this, 
+			new THREE.PlaneBufferGeometry(this.size, this.size, this.segments, this.segments),
+			new THREE.MeshPhongMaterial({
+				color: 0x041020,
+				side: THREE.DoubleSide,
+				wireframe: true
+			}));
+		//Dummy object to avoid bugs when water shader fails
+		this.water = {
+			render: function(){},
+			material: {uniforms: {time: {value: 0}}}};
+		//Axes:
+		this.add(new THREE.AxisHelper(600));
+	}
 	
 	this.waves = [];
 		
@@ -430,16 +466,21 @@ Object.assign(Ocean.prototype, {
 		}
 		return z;
 	},
+	//It appears the y axis was inverted here.
+	//I fixed it, but am not sure how it was wrong.
 	update: function(t) {
 		let pos = this.geometry.getAttribute("position");
 		
 		//REGULAR GRID:
-		for (let j=0; j<this.segments+1; j++) {
-			let y = (j/this.segments-0.5)*this.size;
-			for (let i=0; i<this.segments+1; i++) {
-				let x = (i/this.segments-0.5)*this.size;
+		let size = this.size;
+		let segs = this.segments;
+		let vSize = segs+1
+		for (let j = 0; j < vSize; j++) {
+			let y = (0.5-j/segs)*size;//(j/segs-0.5)*size;
+			for (let i = 0; i < vSize; i++) {
+				let x = (i/segs-0.5)*size;
 				let z = this.calculateZ(x,y,t);
-				pos.setZ(j*(this.segments+1)+i, z);
+				pos.setZ(j*vSize+i, z);
 			}
 		}
 		
@@ -531,7 +572,7 @@ Object.assign(Ocean.prototype, {
 		//IRREGULAR GRID TEST END
 		
 		pos.needsUpdate = true;
-		ocean.geometry.computeVertexNormals();
+		this.geometry.computeVertexNormals();
 		
 		this.water.material.uniforms.time.value = t;
 	}

--- a/examples/js/Jensen.js
+++ b/examples/js/Jensen.js
@@ -1,0 +1,218 @@
+"use strict";
+
+/*
+This does not yet produce proper motion. It is both
+out of phase and out of proportions. One of the problems
+is to get it working with different relative wave 
+directions (both positive and negative cos(beta)).
+The math in the code, as well as in the original paper
+http://www.angelfire.com/ultra/carolemarcio/oceaneng/v31cap4.pdf
+is a bit impenetrable. It is hard to debug.
+
+Another shortcoming is that some parameters are set to
+fixed values, independent of design and conditions.
+This includes the speed parameter, which is set to 0.
+
+Note that the definition of the input waves is given by:
+z = A*cos(phi+2*PI*xm/L-omega*t);
+where
+xm = x*cos(theta)-y*sin(theta);
+theta is wave direction
+x,y are the coordinates to calculate on
+phi is the base phase shift,
+phi+2*PI*xm/L is total phase shift
+omega is angular frequency = 2*PI/T, where T is the period
+A is amplitude
+L is wavelength
+*/
+
+function Jensen(wave, ship, shipState) {
+	this.wave = wave;
+	let T = ship.calculateDraft();
+	let scalc = ship.calculateStability();
+	let hcalc = ship.structure.hull.calculateAttributesAtDraft(T);
+	Object.defineProperties(this, {
+		heading: {
+			get: function() {
+				return shipState.motion.heading;			
+			}
+		},
+		x: {
+			get: function() {
+				return shipState.motion.x;			
+			}
+		},
+		y: {
+			get: function() {
+				return shipState.motion.y;			
+			}
+		}
+	});
+	Object.assign(this, ship.structure.hull.attributes);
+	Object.assign(this, scalc);
+	Object.assign(this, hcalc);
+	this.updateFRFs();
+	this.update(0);
+	console.log(this);
+}
+Jensen.prototype = Object.create(Object.prototype);
+Object.assign(Jensen.prototype, {
+	constructor: Jensen,
+	//New implementation of Jensen's closed-form expressions for estimating vessel motion.
+	//True to Jensen's variable names, for easy comparison and debugging
+	//Only radians and metric units are used.
+	updateFRFs: function() {
+		let abs = Math.abs, cos = Math.cos, sin = Math.sin, exp = Math.exp, sqrt = Math.sqrt, PI=Math.PI;
+		const g = 9.81;
+				
+		//heading of vessel relative to waves, in radians:
+		this.beta = this.wave.theta-this.heading; //Suspicious handling of angles
+		this.cosb = Math.cos(this.beta);
+		this.sinb = Math.sin(this.beta);
+		this.sign = this.cosb < 0 ? -1 : 1;
+
+		const omega = 2*PI/this.wave.T; //angular frequency of waves
+				
+		//WARNING: FIXED VALUE
+		const V = 0;//this.Speed_knots*(463/900); //metric speed of vessel
+		const alpha = 1 - V*this.cosb*omega/g;
+		const omegaBar = alpha*omega;
+		
+		//Note: Assumes "natural" wavelength
+		const k = omega*omega/g; //angular wave number
+
+		//Box model dimensions:
+		let Bb = this.Cb * this.BWL;
+		let L = this.LOA;
+		let T = this.T;
+		
+		//sectional hydrodynamic damping
+		let A = 2*sin(k*Bb*alpha**2/2)*exp(-k*T*alpha**2);
+		
+		let ke = abs(k*this.cosb); //effective wave number
+		let kappa = exp(-ke*T); //Estimate of Smith correction factor
+		
+		//expressions for use by both F and G:
+		let f = sqrt((1-k*T)**2 + A**4/(k*Bb*alpha**3)**2 );
+		let keLh = ke*L/2; //Values from zero to two-figured.
+		
+		//hack to avoid division by approximate zero when beta is +-PI/2.
+		let F, G;
+		if (abs(keLh)<0.01) {
+			F = kappa*f;
+			G = 0; //a bit weird, but seems right, and works (?).
+		} else{
+			F = kappa*f*sin(keLh)/keLh;
+			G = kappa*f*(sin(keLh)/keLh**2-cos(keLh)/keLh)*6/L;
+		}
+		
+		let eta = 1/sqrt((1-2*k*T*alpha**2)**2 + (A/alpha)**4/(k*Bb)**2);
+		
+		//Outputs:
+		this.omegaBar = omegaBar; //Frequency of encounter
+		this.PHIw = F*eta; //heave amplitude multiplier
+		this.PHItheta = G*eta; //pitch amplitude multiplier
+ 
+		//Roll calculations (copy-paste from Olivia's code, with only a few changes):
+		let GM = this.GMt;
+		let Cb = this.Cb;
+		let Cwp = this.Cwp;
+		//WARNING: USING FIXED VALUES
+        let delta = 0.85*Cwp;//vessel.Prism_Length_ratio;
+		let critical_damping_percentage = 0.2;//vessel.critical_damping_percentage;
+		
+		//WARNING: USING FIXED VALUE:
+		let rrg = 0.5;//0.35; //relative radius of gyration		
+        let natural_period = 2*PI*rrg*Bb/sqrt(g*GM); //2PI*k/sqrt(g*GM), where k is the radius of gyration. (http://www.neely-chaulk.com/narciki/Radius_of_gyration)
+		//console.log(natural_period);
+		
+        let restoring_moment_coeff = g*1025*Cb*L*Bb*T*GM; //Cb*Bb is Cb^2*BOA. Right?
+        let breadth_ratio =  (Cwp - delta)/(1 - delta); //gamma
+        let B_1 = breadth_ratio*Bb;
+        let A_0 = Cb*Bb*T/(delta+breadth_ratio*(1-delta)); //Cb*Bb is Cb^2*BOA. Right?
+        let A_1 = breadth_ratio*A_0;
+		
+		//sectional damping coefficient//
+		let Breadth_Draft_ratio = Bb/T;
+		var a0,b0,d0;
+		//3 <= B/T <= 6//
+		if (Breadth_Draft_ratio>3){
+			a0 = 0.256*Breadth_Draft_ratio - 0.286;
+			b0 = -0.11*Breadth_Draft_ratio - 2.55;
+			d0 = 0.033*Breadth_Draft_ratio - 1.419;
+		}
+		//1 <= B/T <= 3//
+		else {
+			a0 = -3.94*Breadth_Draft_ratio + 13.69;
+			b0 = -2.12*Breadth_Draft_ratio - 1.89;
+			d0 = 1.16*Breadth_Draft_ratio-7.97;
+		}
+		
+		Breadth_Draft_ratio = B_1/T;
+		let a1,b1,d1;
+		//3 <= B/T <= 6//
+		if (Breadth_Draft_ratio>3){
+			a1 = 0.256*Breadth_Draft_ratio - 0.286; 
+			b1 = -0.11*Breadth_Draft_ratio - 2.55;
+			d1 = 0.033*Breadth_Draft_ratio - 1.419;
+		}
+		//1 <= B/T <= 3//
+		else {
+			a1=-3.94*Breadth_Draft_ratio + 13.69;
+			b1=-2.12*Breadth_Draft_ratio - 1.89;
+			d1=1.16*Breadth_Draft_ratio-7.97;
+		}
+
+        let b_44_0 = (1025*A_0*Bb*Bb*a0*exp(b0*omegaBar**(-1.3))*omegaBar**d0/(sqrt(Bb/(2*g)))); //2g? Maybe check Jensen's paper.
+        let b_44_1 = (1025*A_1*B_1*B_1*a1*exp(b1*omegaBar**(-1.3))*omegaBar**d1/(sqrt(B_1/(2*g))));
+                
+        let damping_ratio=sqrt(b_44_1/b_44_0);
+                
+        let b_44 = L*b_44_0*(delta + b_44_1*(1-delta)/b_44_0);
+		
+        //total damping = hydro damping + additional damping//       
+        let add_damping = restoring_moment_coeff*natural_period/PI;
+        let roll_hydro_damping= b_44+add_damping*critical_damping_percentage;
+                
+        //excitation frequency//
+		//Note: here is a similar hack to the one I wrote above for the Heave and Pitch
+		let excitation_moment;
+		let srtrhog2b44dob = g*sqrt(1025*b_44_0/omegaBar);
+		if (abs(this.cosb) < 0.001) {
+        //if (abs(beta-PI/2)<0.001 || abs(beta-3*PI/2)<0.001){
+            excitation_moment = srtrhog2b44dob*(delta+damping_ratio*(1-delta))*L;
+        } else { 
+			let A = abs(this.sinb)*srtrhog2b44dob*2/ke;
+            let B = sin(0.5*delta*L*ke)**2;
+            let C = ( damping_ratio*sin(0.5*(1-delta)*L*ke) )**2;
+            let D = 2*damping_ratio*sin(0.5*delta*L*ke)*sin(0.5*(1-delta)*L*ke)*cos(0.5*L*ke);
+               
+            excitation_moment=A*sqrt(B+C+D); 
+        }
+                
+        //main formula//   
+        let B = (1-(abs(omegaBar)*natural_period/(2*PI))**2)**2;
+        let C = restoring_moment_coeff**2; 
+        let D = (abs(omegaBar)*roll_hydro_damping)**2; 
+                
+        //roll output
+        this.PHIphi = excitation_moment/sqrt(B*C+D);  
+	},
+	//This must be adjusted to account for the COSINE ocean waves
+    update: function (t) {
+		//I am not sure this phase shift calculation
+		//will be consistent with omegaBar<>omega.
+		const xm = this.x*this.wave.costh - this.y*this.wave.sinth;
+		const phi = this.wave.phi + 2*Math.PI*xm/this.wave.L;
+		const c = Math.cos(phi-this.omegaBar*t);
+		const s = Math.sin(phi-this.omegaBar*t);
+		const A = this.wave.A;
+		
+		//heave
+		this.heave = this.PHIw*A*c;
+		
+		//rotation. The sign is an attempt at correcting the phase
+		this.pitch = this.sign*this.PHItheta*A*s;
+		this.roll = this.sign*this.PHIphi*A*s;
+    }
+});

--- a/examples/js/Playback.js
+++ b/examples/js/Playback.js
@@ -30,29 +30,31 @@ Object.assign(Playback.prototype, {
 		this.playables.remove(playable);
 	},*/
 	playOrPause: function() {
-		let pn = 0.001*performance.now();
-		
 		if (!this.playing) {
-			if (!this.paused) {
-				this.tStart = pn;
-				this.tLast = this.tStart;
-				this.playing = true;
-			} else {
-				//resume
-				let skip = pn-this.tPaused;
-				this.tStart += skip;
-				this.paused = false;
-				this.playing = true;
-			}
+			this.play();
 		} else {
 			//pause
 			this.playing = false;
 			this.paused = true;
-			this.tPaused = pn;
+			this.tPaused = 0.001*performance.now();
 		}
 	},
 	//This is kept as an alias:
-	play: function(){this.playOrPause()},
+	play: function() {
+		let pn = 0.001*performance.now();
+		if (!this.paused) {
+			//Play from start
+			this.tStart = pn;
+			this.tLast = this.tStart;
+			this.playing = true;
+		} else {
+			//Resume
+			let skip = pn-this.tPaused;
+			this.tStart += skip;
+			this.paused = false;
+			this.playing = true;
+		}
+	},
 	stop: function() {
 		this.playing = false;
 		this.paused = false;

--- a/examples/js/Playback.js
+++ b/examples/js/Playback.js
@@ -9,7 +9,7 @@ have to be done within the update functions.)*/
 
 "use strict";
 
-function Playback(params) {
+function Playback(params={}) {
 	if (params.parentGUI) {
 		this.conf = params.parentGUI.addFolder("Playback")
 		this.conf.open();
@@ -51,6 +51,7 @@ Object.assign(Playback.prototype, {
 			//Resume
 			let skip = pn-this.tPaused;
 			this.tStart += skip;
+			this.tLast += skip;
 			this.paused = false;
 			this.playing = true;
 		}

--- a/examples/js/Ship3D.js
+++ b/examples/js/Ship3D.js
@@ -328,7 +328,7 @@ Object.assign(Ship3D.prototype, {
 		let bo = object.baseObject;
 		
 		//Position
-		s = this.ship.designState.getObjectState(object);
+		let s = this.ship.designState.getObjectState(object);
 		let x = s.xCentre;
 		let y = s.yCentre;
 		let z = s.zBase;

--- a/examples/js/Ship3D_v2.js
+++ b/examples/js/Ship3D_v2.js
@@ -100,15 +100,17 @@ function Ship3D(ship, {shipState, stlPath, upperColor, lowerColor, hullOpacity, 
 	let deckMat = new THREE.MeshPhongMaterial({color: 0xcccccc/*this.randomColor()*/, transparent: true, opacity: deckOpacity, side: THREE.DoubleSide});
 	//deckGeom.translate(0,0,-0.5);
 	let ds = ship.structure.decks;
-	let dk = Object.keys(ds);
+	//let dk = Object.keys(ds);
 	let stss = stations.map(st=>LOA*st); //use scaled stations for now
-	console.log(dk);
-	for (let i = 0; i < dk.length; i++) {
-		let d = ds[dk[i]]; //deck in ship structure
+	//console.log(dk);
+	//for (let i = 0; i < dk.length; i++) {
+	for (let dk in ds) {
+		//let d = ds[dk[i]]; //deck in ship structure
+		let d = ds[dk];
 		
 		//Will eventually use BoxBufferGeometry, but that is harder, because vertices are duplicated in the face planes.
 		let deckGeom = new THREE.PlaneBufferGeometry(1, 1, stss.length, 1);//new THREE.BoxBufferGeometry(1,1,1,sts.length,1,1);
-		console.log("d.zFloor=%.1f", d.zFloor); //DEBUG
+		//console.log("d.zFloor=%.1f", d.zFloor); //DEBUG
 		let zHigh = d.zFloor;
 		let zLow = d.zFloor-d.thickness;
 		let wlHigh = hull.getWaterline(zHigh);
@@ -128,11 +130,11 @@ function Ship3D(ship, {shipState, stlPath, upperColor, lowerColor, hullOpacity, 
 		pos.needsUpdate = true;
 		
 		//DEBUG
-		console.log("d.xFwd=%.1f, d.xAft=%.1f, 0.5*d.breadth=%.1f", d.xFwd, d.xAft, 0.5*d.breadth);
-		console.log(pa);
+		//console.log("d.xFwd=%.1f, d.xAft=%.1f, 0.5*d.breadth=%.1f", d.xFwd, d.xAft, 0.5*d.breadth);
+		//console.log(pa);
 
 		let deck = new THREE.Mesh(deckGeom, deckMat);
-		deck.name = dk[i];
+		deck.name = dk;//[i];
 		deck.position.z = d.zFloor;
 		//deck.scale.set(d.xFwd-d.xAft, d.breadth, d.thickness);
 		//deck.position.set(0.5*(d.xFwd+d.xAft), 0, d.zFloor);
@@ -149,11 +151,12 @@ function Ship3D(ship, {shipState, stlPath, upperColor, lowerColor, hullOpacity, 
 	let bhMat = new THREE.MeshPhongMaterial({color: 0xcccccc/*this.randomColor()*/, transparent: true, opacity: deckOpacity, side: THREE.DoubleSide});
 	bhGeom.translate(0.5,0,0);
 	let bhs = ship.structure.bulkheads;
-	let bhk = Object.keys(bhs);
-	for (let i = 0; i < bhk.length; i++) {
+	//let bhk = Object.keys(bhs);
+	//for (let i = 0; i < bhk.length; i++) {
+	for (let bhk in bhs) {
 		let bulkhead = new THREE.Mesh(bhGeom, bhMat);
-		let bh = bhs[bhk[i]];
-		bulkhead.name = bhk[i];
+		let bh = bhs[bhk];//bhs[bhk[i]];
+		bulkhead.name = bhk;//[i];
 		bulkhead.scale.set(bh.thickness, 1, 1);
 		bulkhead.position.set(bh.xAft, 0, 0);
 		bulkheads.add(bulkhead);
@@ -270,9 +273,9 @@ function Hull3D(hull, upperColor=0x33aa33, lowerColor=0xaa3333, design_draft, op
 	let table = hull.halfBreadths.table;
 	//None of these are changed during correction of the geometry.
 
-	console.log(stations);
-	console.log(waterlines);
-	console.log(table);
+	//console.log(stations);
+	//console.log(waterlines);
+	//console.log(table);
 	
 	let N = stations.length;
 	let M = waterlines.length;
@@ -339,14 +342,14 @@ function Hull3D(hull, upperColor=0x33aa33, lowerColor=0xaa3333, design_draft, op
 				}
 				break;
 			}
-			console.log("null encountered.");
+			//console.log("null encountered.");
 		}
 		
 		//Continue up the hull (with same j counter), searching for upper number. This does not account for the existence of numbers above the first null encountered.
 		for (; j < M; j++) {
 			let y = table[j][i];
 			if (y === null) {
-				console.log("null encountered.");
+				//console.log("null encountered.");
 				break;
 			}
 			//else not null:

--- a/examples/js/Ship3D_v2.js
+++ b/examples/js/Ship3D_v2.js
@@ -28,6 +28,7 @@ function Ship3D(ship, {shipState, stlPath, upperColor, lowerColor, hullOpacity, 
 	
 	this.normalizer = new THREE.Group();
 	this.fluctCont = new THREE.Group();
+	this.fluctCont.rotation.order = "ZYX"; //right?
 	this.cmContainer = new THREE.Group();
 	this.fluctCont.add(this.cmContainer);
 	this.normalizer.add(this.fluctCont);
@@ -204,7 +205,7 @@ Object.assign(Ship3D.prototype, {
 		let bo = object.baseObject;
 		
 		//Position
-		s = this.ship.designState.getObjectState(object);
+		let s = this.ship.designState.getObjectState(object);
 		let x = s.xCentre;
 		let y = s.yCentre;
 		let z = s.zBase;

--- a/source/classes/BaseObject.js
+++ b/source/classes/BaseObject.js
@@ -64,7 +64,7 @@ Object.assign(BaseObject.prototype, {
 				cg.push(c);
 			}
 		} else if (wi.cg !== undefined) {
-			console.log("BaseObject.getWeight: Using specified cg.");
+			//console.log("BaseObject.getWeight: Using specified cg.");
 			cg = wi.cg;
 		} else {
 			console.warn("BaseObject.getWeight: No cg or fullnessCGMapping supplied. Defaults to center of bounding box.");

--- a/source/classes/Hull.js
+++ b/source/classes/Hull.js
@@ -45,7 +45,7 @@ Object.assign(Hull.prototype, {
 		parsons.mass *= 1000; //ad hoc conversion to kg, because the example K value is aimed at ending with tonnes.
 		
 		let output = parsons;
-		console.info("Hull weight:", output);
+		//console.info("Hull weight:", output);
 		return output;
 	},
 	/*
@@ -65,12 +65,12 @@ Object.assign(Hull.prototype, {
 		let tab = this.halfBreadths.table;
 
 		if (zr<wls[0]) {
-				console.warn("getWaterLine: z below lowest defined waterline. Defaulting to all zero offsets.");
+				//console.warn("getWaterLine: z below lowest defined waterline. Defaulting to all zero offsets.");
 				return new Array(sts.length).fill(0);
 		} else {
 			let a, mu;
 			if (zr>wls[wls.length-1]) {
-				console.warn("getWaterLine: z above highest defined waterline. Proceeding with highest data entries.");
+				//console.warn("getWaterLine: z above highest defined waterline. Proceeding with highest data entries.");
 				a = wls.length-2; //if this level is defined...
 				mu=1;
 				//wl = tab[a].slice();
@@ -388,7 +388,7 @@ Object.assign(Hull.prototype, {
 					patchColumnCalculation(sts[j], sts[j+1], prev.z, z, prwl[j], wl[j], prwl[j+1], wl[j+1]);
 				calculations.push(star);
 			}
-			console.log(calculations); //DEBUG
+			//console.log(calculations); //DEBUG
 			let C = combineVolumes(calculations);
 			//Cv of slice. Note that switching of yz must
 			//be done before combining with previous level
@@ -444,8 +444,8 @@ Object.assign(Hull.prototype, {
 			//Find highest data waterline below or at water level:
 			let {index, mu} = bisectionSearch(wls, T);
 			
-			console.info("Highest data waterline below or at water level: " + index);
-			console.log(this.levels);
+			//console.info("Highest data waterline below or at water level: " + index);
+			//console.log(this.levels);
 			let lc;
 			if (mu===0) lc = this.levels[index];
 			else lc = levelCalculation(this, T, this.levels[index]);
@@ -491,11 +491,11 @@ Object.assign(Hull.prototype, {
 		while (b-a>epsilon) {
 			t = 0.5*(a+b);
 			let V = this.calculateAttributesAtDraft(t)["Vs"];
-			console.log(V); //DEBUG
+			//console.log(V); //DEBUG
 			if (V>VT) b = t;
 			else a = t;
 		}
-		console.info("Calculated draft: %.2f", t);
+		//console.info("Calculated draft: %.2f", t);
 		return t;
 	}
 });

--- a/source/classes/Ship.js
+++ b/source/classes/Ship.js
@@ -56,14 +56,14 @@ Object.assign(Ship.prototype, {
 		);
 		
 		//DEBUG
-		console.log(components);
+		//console.log(components);
 
 		for (let o of Object.values(this.derivedObjects)) {
 			components.push(o.getWeight(shipState));
 		}
 
 		var W = combineWeights(components);
-		console.info("Calculated weight object: ", W);
+		//console.info("Calculated weight object: ", W);
 		return W;
 	},
 	calculateDraft: function(shipState, epsilon=0.001, rho=1025) {
@@ -111,7 +111,7 @@ Object.assign(Ship.prototype, {
 			if (mass <= tkMass) { // if yes, subtract mass
 				shipState.objectCache[tkId].state.fullness -= mass/(this.derivedObjects[tkId].baseObject.weightInformation.volumeCapacity * this.derivedObjects[tkId].baseObject.weightInformation.contentDensity);
 				mass = 0;
-				console.log("Vessel is sailing on fuel from " + tkId + ".");
+				//console.log("Vessel is sailing on fuel from " + tkId + ".");
 			} else { // if not, make tank empty
 				mass -= tkMass;
 				shipState.objectCache[tkId].state.fullness = 0;

--- a/source/classes/ShipState.js
+++ b/source/classes/ShipState.js
@@ -1,9 +1,9 @@
 //@EliasHasle
 
 /*
-The object state assignments could/should also have a baseByGroup. A group of baseObjects could for instance be a category including all tanks that carry a given compound, regardless of their size and shape. Maybe "group" is not a good name for something that can be set freely. Maybe "label" or "tag" or something else. The same goes for derivedByGroup.
+The object state assignments can now target baseByGroup. A group of baseObjects can for instance be a category including all tanks that carry a given compound, regardless of their size and shape. Maybe "group" is not a good name for something that can be set freely. Maybe "label" or "tag" or something else. The same goes for derivedByGroup.
 
-With this, there would be five types of assignments:
+Now there are five types of assignments in this class:
 common: All objects.
 baseByGroup: Applies to every object that has its base object's property "group" set to the given name.
 baseByID: Applies to all objects that have base object consistent with the given ID:
@@ -11,6 +11,8 @@ derivedByGroup: Applies to every object that has its property "group" set to the
 derivedByID: Applies only to the object with given ID.
 
 Assignments of subsequent types override assignments of previous types.
+
+Note that the foundation for object state is laid in baseObject.baseState and derivedObject.referenceState. The abovementioned assignments apply only as overrides. They do not introduce new properties.
 */
 
 /*
@@ -51,28 +53,38 @@ Object.assign(ShipState.prototype, {
 	clone: function() {
 		return new ShipState(this.getSpecification());
 	},
+	//Method to get the state of a DerivedObject
 	getObjectState: function(o) {
 		if (this.objectCache[o.id] !== undefined) {
 			let c = this.objectCache[o.id];
 			if (c.thisStateVer === this.version
 				/*&& c.baseStateVer === o.baseObject.baseStateVersion
 				&& c.refStateVer === o.referenceStateVersion*/) {
-				console.log("ShipState.getObjectState: Using cache.");
+				//console.log("ShipState.getObjectState: Using cache.");
 				return c.state;	
 			}				
 		}
-		console.log("ShipState.getObjectState: Not using cache.");
+		//console.log("ShipState.getObjectState: Not using cache.");
 		
+		//Build the state in multiple steps,
+		//such that the later steps override
+		//the earlier ones when in conflict.
+		//The two first steps lay the foundation.
 		let state = {};
+		//1.
 		Object.assign(state, o.baseObject.baseState);
+		//2.
 		Object.assign(state, o.referenceState);
+		//The next steps are different, because there,
+		//only existing properties will be updated.
 		let oo = this.objectOverrides;
-		let sources = [oo.common, oo.baseByID[o.baseObject.id], oo.derivedByGroup[o.affiliations.group], oo.derivedByID[o.id]];
+		//3., 4., 5., 6.
+		let sources = [oo.common, oo.baseByGroup[o.baseObject.group], oo.baseByID[o.baseObject.id], oo.derivedByGroup[o.affiliations.group], oo.derivedByID[o.id]];
 		for (let i = 0; i < sources.length; i++) {
 			let s = sources[i];
 			if (!s) continue;
-			let sk = Object.keys(s);
-			for (let k of sk) {
+			//let sk = Object.keys(s);
+			for (let k in/*of*/ s) {//(sk) {
 				//Override existing properties only:
 				if (state[k] !== undefined) {
 					state[k] = s[k];
@@ -80,6 +92,8 @@ Object.assign(ShipState.prototype, {
 			}
 		}
 		
+		//Cache the result, conditioned on the ShipState version
+		//(not good, should restrict the dependency more)
 		this.objectCache[o.id] = {
 			thisStateVer: this.version,
 			/*baseStateVer: o.baseObject.baseStateVersion,
@@ -94,7 +108,7 @@ Object.assign(ShipState.prototype, {
 		return this.getObjectState(o)[k];
 		//I have commented out a compact, but not very efficient, implementation of Alejandro's pattern, that does not fit too well with my caching solution.
 /*		let oo = this.objectOverrides;
-		let sources = [oo.derivedByID[o.id], oo.derivedByGroup[o.affiliations.group], oo.baseByID[o.baseObject.id], oo.common, o.getReferenceState(), o.baseObject.getBaseState()].filter(e=>!!e);
+		let sources = [oo.derivedByID[o.id], oo.derivedByGroup[o.affiliations.group], oo.baseByID[o.baseObject.id], oo.baseByGroup[o.baseObject.group], oo.common, o.getReferenceState(), o.baseObject.getBaseState()].filter(e=>!!e);
 		for (let i = 0; i < sources.length; i++) {
 			if (sources[i][k] !== undefined) return sources[i][k];
 		}
@@ -109,7 +123,7 @@ Object.assign(ShipState.prototype, {
 				//Named overrides because only existing corresponding properties will be set
 				objectOverrides: {
 					commmon: {},
-					//baseByGroup: {},
+					baseByGroup: {},
 					baseByID: {},
 					derivedByGroup: {},
 					derivedByID: {}
@@ -123,6 +137,7 @@ Object.assign(ShipState.prototype, {
 		let oo = this.objectOverrides;
 		let soo = spec.objectOverrides || {};
 		oo.common = soo.common || {};
+		oo.baseByGroup = soo.baseByGroup || {};
 		oo.baseByID = soo.baseByID || {};
 		oo.derivedByGroup = soo.derivedByGroup || {};
 		oo.derivedByID = soo.derivedByID || {};
@@ -136,8 +151,8 @@ Object.assign(ShipState.prototype, {
 		let oo = this.objectOverrides;
 		let soo = spec.objectOverrides || {};
 		Object.assign(oo.common, soo.common);
-		let sources = [soo.baseByID, soo.derivedByGroup, soo.derivedByID];
-		let targets = [oo.baseByID, oo.derivedByGroup, oo.derivedByID];
+		let sources = [soo.baseByGroup, soo.baseByID, soo.derivedByGroup, soo.derivedByID];
+		let targets = [oo.baseByGroup, oo.baseByID, oo.derivedByGroup, oo.derivedByID];
 		for (let i = 0; i < sources.length; i++) {
 			if (!sources[i]) continue;
 			let sk = Object.keys(sources[i]);
@@ -169,8 +184,8 @@ Object.assign(ShipState.prototype, {
 			}
 		}
 
-		sources = [soo.common, soo.baseByID, soo.derivedByGroup, soo.derivedByID];
-		targets = [oo.common, oo.baseByID, oo.derivedByGroup, oo.derivedByID];
+		sources = [soo.common, soo.baseByGroup, soo.baseByID, soo.derivedByGroup, soo.derivedByID];
+		targets = [oo.common, oo.baseByGroup, oo.baseByID, oo.derivedByGroup, oo.derivedByID];
 		
 		for (let i = 0; i < sources.length; i++) {
 			if (!sources[i]) continue;

--- a/source/classes/ShipState_new.js
+++ b/source/classes/ShipState_new.js
@@ -1,9 +1,15 @@
 //@EliasHasle
 
 /*
-The object state assignments could/should also have a baseByGroup. A group of baseObjects could for instance be a category including all tanks that carry a given compound, regardless of their size and shape. Maybe "group" is not a good name for something that can be set freely. Maybe "label" or "tag" or something else. The same goes for derivedByGroup.
+Changes are coming. Caching of object states is now decoupled from the rest of the state, to avoid needless recalculation on every little motion or other dynamical change.
 
-With this, there would be five types of assignments:
+In addition to this, a motion object is added.
+*/
+
+/*
+The object state assignments can now target baseByGroup. A group of baseObjects can for instance be a category including all tanks that carry a given compound, regardless of their size and shape. Maybe "group" is not a good name for something that can be set freely. Maybe "label" or "tag" or something else. The same goes for derivedByGroup.
+
+Now there are five types of assignments in this class:
 common: All objects.
 baseByGroup: Applies to every object that has its base object's property "group" set to the given name.
 baseByID: Applies to all objects that have base object consistent with the given ID:
@@ -11,6 +17,8 @@ derivedByGroup: Applies to every object that has its property "group" set to the
 derivedByID: Applies only to the object with given ID.
 
 Assignments of subsequent types override assignments of previous types.
+
+Note that the foundation for object state is laid in baseObject.baseState and derivedObject.referenceState. The abovementioned assignments apply only as overrides. They do not introduce new properties.
 */
 
 /*
@@ -34,45 +42,63 @@ ShipState.prototype = Object.create(JSONSpecObject.prototype);
 Object.assign(ShipState.prototype, {
 	constructor: ShipState,
 	getSpecification: function() {
-		if (this.cachedVersion !== this.version) {
+		if (this.cachedSpecVersion !== this.version) {
 			var spec = {
 				calculationParameters: this.calculationParameters,
-				objectOverrides: this.objectOverrides//{}
+				motion: this.motion,
+				objectOverrides: {
+					//(don't export version)
+					this.objectOverrides.common,
+					this.objectOverrides.baseByGroup,
+					this.objectOverrides.baseByID,
+					this.objectOverrides.derivedByGroup,
+					this.objectOverrides.derivedByID
+				}
 			};
 			
-			//Sketchy, but versatile:
+			//Sketchy, but versatile, deep-copy pattern:
 			spec = JSON.parse(JSON.stringify(spec));		
 			
 			this.specCache = spec;
-			this.cachedVersion = this.version;
+			this.cachedSpecVersion = this.version;
 		}
 		return this.specCache;
 	},
 	clone: function() {
 		return new ShipState(this.getSpecification());
 	},
+	//Method to get the state of a DerivedObject
 	getObjectState: function(o) {
 		if (this.objectCache[o.id] !== undefined) {
 			let c = this.objectCache[o.id];
-			if (c.thisStateVer === this.version
+			if (c.overridesStateVer === this.objectOverrides.version
 				/*&& c.baseStateVer === o.baseObject.baseStateVersion
 				&& c.refStateVer === o.referenceStateVersion*/) {
-				console.log("ShipState.getObjectState: Using cache.");
+				//console.log("ShipState.getObjectState: Using cache.");
 				return c.state;	
 			}				
 		}
-		console.log("ShipState.getObjectState: Not using cache.");
+		//console.log("ShipState.getObjectState: Not using cache.");
 		
+		//Build the state in multiple steps,
+		//such that the later steps override
+		//the earlier ones when in conflict.
+		//The two first steps lay the foundation.
 		let state = {};
-		Object.assign(state, o.baseObject.baseState);
-		Object.assign(state, o.referenceState);
+		//1.
+		Object.assign(state, o.baseObject.baseState); //unsafe for nested objects
+		//2.
+		Object.assign(state, o.referenceState); //unsafe for nested objects
+		//The next steps are different, because there,
+		//only existing properties will be updated.
 		let oo = this.objectOverrides;
-		let sources = [oo.common, oo.baseByID[o.baseObject.id], oo.derivedByGroup[o.affiliations.group], oo.derivedByID[o.id]];
+		//3., 4., 5., 6.
+		let sources = [oo.common, oo.baseByGroup[o.baseObject.group], oo.baseByID[o.baseObject.id], oo.derivedByGroup[o.affiliations.group], oo.derivedByID[o.id]];
 		for (let i = 0; i < sources.length; i++) {
 			let s = sources[i];
 			if (!s) continue;
-			let sk = Object.keys(s);
-			for (let k of sk) {
+			//let sk = Object.keys(s);
+			for (let k in/*of*/ s) {//(sk) {
 				//Override existing properties only:
 				if (state[k] !== undefined) {
 					state[k] = s[k];
@@ -80,8 +106,10 @@ Object.assign(ShipState.prototype, {
 			}
 		}
 		
+		//Cache the result, conditioned on the ShipState version
+		//(not good, should restrict the dependency more)
 		this.objectCache[o.id] = {
-			thisStateVer: this.version,
+			overridesStateVer: this.objectOverrides.version,
 			/*baseStateVer: o.baseObject.baseStateVersion,
 			refStateVer: o.referenceStateVersion,*/
 			state: state
@@ -94,39 +122,51 @@ Object.assign(ShipState.prototype, {
 		return this.getObjectState(o)[k];
 		//I have commented out a compact, but not very efficient, implementation of Alejandro's pattern, that does not fit too well with my caching solution.
 /*		let oo = this.objectOverrides;
-		let sources = [oo.derivedByID[o.id], oo.derivedByGroup[o.affiliations.group], oo.baseByID[o.baseObject.id], oo.common, o.getReferenceState(), o.baseObject.getBaseState()].filter(e=>!!e);
+		let sources = [oo.derivedByID[o.id], oo.derivedByGroup[o.affiliations.group], oo.baseByID[o.baseObject.id], oo.baseByGroup[o.baseObject.group], oo.common, o.getReferenceState(), o.baseObject.getBaseState()].filter(e=>!!e);
 		for (let i = 0; i < sources.length; i++) {
 			if (sources[i][k] !== undefined) return sources[i][k];
 		}
 		return; //undefined*/
 	},
 	//Sets this state exclusively from parameter.
-	setFromSpecification: function(spec) {
+	setFromSpecification: function(spec={}) {
 		this.objectCache = {}; //reset cache
-		if (!spec) {
-			Object.assign(this, {
-				calculationParameters: {},
-				//Named overrides because only existing corresponding properties will be set
-				objectOverrides: {
-					commmon: {},
-					//baseByGroup: {},
-					baseByID: {},
-					derivedByGroup: {},
-					derivedByID: {}
-				}
-			});
-			return;
-		}
 
 		this.calculationParameters = spec.calculationParameters || {};
-		this.objectOverrides = {};
-		let oo = this.objectOverrides;
-		let soo = spec.objectOverrides || {};
-		oo.common = soo.common || {};
-		oo.baseByID = soo.baseByID || {};
-		oo.derivedByGroup = soo.derivedByGroup || {};
-		oo.derivedByID = soo.derivedByID || {};
 		
+		//This is new:
+		this.motion = spec.motion || 
+					{
+						heave: 0,
+						pitch: 0,
+						roll: 0,
+						heading: 0,
+						speed: 0,
+					};
+
+		let prevVer = typeof this.objectOverrides === "undefined" ? -1 : this.objectOverrides.version;
+
+		if (spec.objectOverrides) {
+			this.objectOverrides = {};
+			let oo = this.objectOverrides;
+			let soo = spec.objectOverrides || {};
+			oo.common = soo.common || {};
+			oo.baseByGroup = soo.baseByGroup || {};
+			oo.baseByID = soo.baseByID || {};
+			oo.derivedByGroup = soo.derivedByGroup || {};
+			oo.derivedByID = soo.derivedByID || {};
+		} else {
+			//Named "overrides" because only existing corresponding properties will be set
+			this.objectOverrides = {
+				common: {},
+				baseByGroup: {},
+				baseByID: {},
+				derivedByGroup: {},
+				derivedByID: {}
+			}
+		}
+		
+		this.objectOverrides.version = prevVer+1;
 		this.version++;
 	},
 	//Overrides existing directives and adds new ones.
@@ -136,12 +176,11 @@ Object.assign(ShipState.prototype, {
 		let oo = this.objectOverrides;
 		let soo = spec.objectOverrides || {};
 		Object.assign(oo.common, soo.common);
-		let sources = [soo.baseByID, soo.derivedByGroup, soo.derivedByID];
-		let targets = [oo.baseByID, oo.derivedByGroup, oo.derivedByID];
+		let sources = [soo.baseByGroup, soo.baseByID, soo.derivedByGroup, soo.derivedByID];
+		let targets = [oo.baseByGroup, oo.baseByID, oo.derivedByGroup, oo.derivedByID];
 		for (let i = 0; i < sources.length; i++) {
 			if (!sources[i]) continue;
-			let sk = Object.keys(sources[i]);
-			for (let k of sk) {
+			for (let k in sources[i]) {
 				if (targets[i][k] !== undefined) {
 					Object.assign(targets[i][k], sources[i][k]);
 				} else {
@@ -150,6 +189,7 @@ Object.assign(ShipState.prototype, {
 			}
 		}
 
+		this.objectOverrides.version++;
 		this.version++;
 	},
 	//Applies only directives of spec that have a corresponding directive in this.
@@ -161,28 +201,25 @@ Object.assign(ShipState.prototype, {
 		let targets = [this.calculationParameters, oo.common];
 		for (let i = 0; i < sources.length; i++) {
 			if (!sources[i]) continue;
-			let sk = Object.keys(sources[i]);
-			for (let k of sk) {
+			for (let k in sources[i]) {
 				if (targets[i][k] !== undefined) {
 					targets[i][k] = sources[i][k];
 				}
 			}
 		}
 
-		sources = [soo.common, soo.baseByID, soo.derivedByGroup, soo.derivedByID];
-		targets = [oo.common, oo.baseByID, oo.derivedByGroup, oo.derivedByID];
+		sources = [soo.common, soo.baseByGroup, soo.baseByID, soo.derivedByGroup, soo.derivedByID];
+		targets = [oo.common, oo.baseByGroup, oo.baseByID, oo.derivedByGroup, oo.derivedByID];
 		
 		for (let i = 0; i < sources.length; i++) {
 			if (!sources[i]) continue;
-			let specKeys = Object.keys(sources[i]);
-			for (let key of specKeys) {
+			for (let key in sources[i]) {
 				if (targets[i][key] !== undefined) {
 					let t = targets[i][key];
 					let s = sources[i][key];
 					if (!s) continue;
-					let sk = Object.keys(s);
 					//Loop over individual properties in assignments, and override only:
-					for (let k of sk) {
+					for (let k in s) {
 						if (t[k] !== undefined) {
 							t[k] = s[k];
 						}
@@ -191,6 +228,7 @@ Object.assign(ShipState.prototype, {
 			}
 		}
 
+		this.objectOverrides.version++;
 		this.version++;
 	}
 });

--- a/source/classes/Structure.js
+++ b/source/classes/Structure.js
@@ -50,7 +50,7 @@ Object.assign(Structure.prototype, {
 		
 		return spec;
 	},
-	//Alejandro is working on a more proper calculation of this
+	//This is all dummy calculations
 	getWeight: function(designState) {
 		let components = [];
 		//Hull
@@ -92,7 +92,7 @@ Object.assign(Structure.prototype, {
 		}
 		
 		let output = combineWeights(components);
-		console.info("Total structural weight: ", output);
+		//console.info("Total structural weight: ", output);
 		return output;
 	}
 });

--- a/source/math/areaCalculations.js
+++ b/source/math/areaCalculations.js
@@ -69,8 +69,8 @@ function combineAreas(array) {
 		xc /= A;
 		yc /= A;
 	} else {
-		console.warn("Zero area combination.");
-		console.trace();
+		//console.warn("Zero area combination.");
+		//console.trace();
 		xc /= L;
 		yc /= L;
 	}

--- a/source/math/interpolation.js
+++ b/source/math/interpolation.js
@@ -66,7 +66,7 @@ function bilinearCoeffs(x1, x2, y1, y2, z00, z01, z10, z11) {
 	let Y = (y2-y1);
 	
 	if (X===0 || Y=== 0) {
-		console.warn("bilinearCoeffs: Zero base area. Setting coefficients to zero.");
+		//console.warn("bilinearCoeffs: Zero base area. Setting coefficients to zero.");
 		return [0,0,0,0];
 	}
 	


### PR DESCRIPTION
- Three new multibody examples
- Reduced console output.
- Corrected flipped y axis in Ocean in examples.
- Some other small fixes.
- Added shipState.objectOverrides.baseByGroup, for completeness.
- Sketched some properties of new ShipState in ShipState_new.js. (Cluttering, I know.)

The Jensen multibody example does not work very well yet.

ShipState_new.js is not tested or in use. It just points out a possible direction for future development. In fact, I think a new ShipState must be very different, if the goal is to have efficient, seamless caching (when necessary) and good integration with Ship3D and other potential users of the class. We will probably have to use Proxy objects and Object.defineProperty with custom getters/setters. Maybe we will even want to have a ShipSimulation class that connects a Ship with a ShipState, and reports to Ship3D and others that connect to it.