### PR TITLE
Disable cache in ShipState

### DIFF
--- a/build/vessel.js
+++ b/build/vessel.js
@@ -1,4 +1,4 @@
-//vessel.js library, built 2019-09-29 13:43:45.187788
+//vessel.js library, built 2019-09-29 13:52:49.873551
 /*
 Import like this in HTML:
 <script src="vessel.js"></script>
@@ -1680,7 +1680,7 @@ Assignments of subsequent types override assignments of previous types.
 */
 
 /*
-The caching and version control is clumsy (and incomplete). I (Elias) have done some separate testing of ways to do it properly. This must be implemented later.
+The caching and version control is clumsy (and incomplete (and DISABLED)). I (Elias) have done some separate testing of ways to do it properly. This must be implemented later.
 */
 
 /*
@@ -1688,8 +1688,8 @@ ShipState now mainly accounts for load state, by which I mean the states of obje
 */
 
 function ShipState(specification) {
-	this.version = 0;
-	this.objectCache = {};
+	//this.version = 0;
+	//this.objectCache = {};
 	this.continuous = {};
 	this.discrete = {};
 	JSONSpecObject.call(this, specification);
@@ -1698,7 +1698,7 @@ ShipState.prototype = Object.create(JSONSpecObject.prototype);
 Object.assign(ShipState.prototype, {
 	constructor: ShipState,
 	getSpecification: function() {
-		if (this.cachedVersion !== this.version) {
+		//if (this.cachedVersion !== this.version) {
 			var spec = {
 				calculationParameters: this.calculationParameters,
 				objectOverrides: this.objectOverrides//{}
@@ -1706,26 +1706,26 @@ Object.assign(ShipState.prototype, {
 
 			//Sketchy, but versatile:
 			spec = JSON.parse(JSON.stringify(spec));
-
-			this.specCache = spec;
-			this.cachedVersion = this.version;
-		}
-		return this.specCache;
+			return spec;
+			//this.specCache = spec;
+			//this.cachedVersion = this.version;
+		//}
+		//return this.specCache;
 	},
 	clone: function() {
 		return new ShipState(this.getSpecification());
 	},
 	getObjectState: function(o) {
-		if (this.objectCache[o.id] !== undefined) {
-			let c = this.objectCache[o.id];
-			if (c.thisStateVer === this.version
-				/*&& c.baseStateVer === o.baseObject.baseStateVersion
-				&& c.refStateVer === o.referenceStateVersion*/) {
-				console.log("ShipState.getObjectState: Using cache.");
-				return c.state;
-			}
-		}
-		console.log("ShipState.getObjectState: Not using cache.");
+		// if (this.objectCache[o.id] !== undefined) {
+			// let c = this.objectCache[o.id];
+			// if (c.thisStateVer === this.version
+				// /*&& c.baseStateVer === o.baseObject.baseStateVersion
+				// && c.refStateVer === o.referenceStateVersion*/) {
+				// console.log("ShipState.getObjectState: Using cache.");
+				// return c.state;
+			// }
+		// }
+		// console.log("ShipState.getObjectState: Not using cache.");
 
 		let state = {};
 		Object.assign(state, o.baseObject.baseState);
@@ -1744,12 +1744,12 @@ Object.assign(ShipState.prototype, {
 			}
 		}
 
-		this.objectCache[o.id] = {
-			thisStateVer: this.version,
-			/*baseStateVer: o.baseObject.baseStateVersion,
-			refStateVer: o.referenceStateVersion,*/
-			state: state
-		};
+		// this.objectCache[o.id] = {
+			// thisStateVer: this.version,
+			// /*baseStateVer: o.baseObject.baseStateVersion,
+			// refStateVer: o.referenceStateVersion,*/
+			// state: state
+		// };
 
 		return state;
 	},
@@ -1791,7 +1791,7 @@ Object.assign(ShipState.prototype, {
 		oo.derivedByGroup = soo.derivedByGroup || {};
 		oo.derivedByID = soo.derivedByID || {};
 
-		this.version++;
+		//this.version++;
 
 		return this;
 	},
@@ -1816,7 +1816,7 @@ Object.assign(ShipState.prototype, {
 			}
 		}
 
-		this.version++;
+		//this.version++;
 	},
 	//Applies only directives of spec that have a corresponding directive in this.
 	override: function(spec) {
@@ -1857,7 +1857,7 @@ Object.assign(ShipState.prototype, {
 			}
 		}
 
-		this.version++;
+		//this.version++;
 	}
 });function StateModule(ship, states) {
 	this.ship = ship;

--- a/source/classes/ShipState.js
+++ b/source/classes/ShipState.js
@@ -14,7 +14,7 @@ Assignments of subsequent types override assignments of previous types.
 */
 
 /*
-The caching and version control is clumsy (and incomplete). I (Elias) have done some separate testing of ways to do it properly. This must be implemented later.
+The caching and version control is clumsy (and incomplete (and DISABLED)). I (Elias) have done some separate testing of ways to do it properly. This must be implemented later.
 */
 
 /*
@@ -22,8 +22,8 @@ ShipState now mainly accounts for load state, by which I mean the states of obje
 */
 
 function ShipState(specification) {
-	this.version = 0;
-	this.objectCache = {};
+	//this.version = 0;
+	//this.objectCache = {};
 	this.continuous = {};
 	this.discrete = {};
 	JSONSpecObject.call(this, specification);
@@ -32,7 +32,7 @@ ShipState.prototype = Object.create(JSONSpecObject.prototype);
 Object.assign(ShipState.prototype, {
 	constructor: ShipState,
 	getSpecification: function() {
-		if (this.cachedVersion !== this.version) {
+		//if (this.cachedVersion !== this.version) {
 			var spec = {
 				calculationParameters: this.calculationParameters,
 				objectOverrides: this.objectOverrides//{}
@@ -40,26 +40,26 @@ Object.assign(ShipState.prototype, {
 
 			//Sketchy, but versatile:
 			spec = JSON.parse(JSON.stringify(spec));
-
-			this.specCache = spec;
-			this.cachedVersion = this.version;
-		}
-		return this.specCache;
+			return spec;
+			//this.specCache = spec;
+			//this.cachedVersion = this.version;
+		//}
+		//return this.specCache;
 	},
 	clone: function() {
 		return new ShipState(this.getSpecification());
 	},
 	getObjectState: function(o) {
-		if (this.objectCache[o.id] !== undefined) {
-			let c = this.objectCache[o.id];
-			if (c.thisStateVer === this.version
-				/*&& c.baseStateVer === o.baseObject.baseStateVersion
-				&& c.refStateVer === o.referenceStateVersion*/) {
-				console.log("ShipState.getObjectState: Using cache.");
-				return c.state;
-			}
-		}
-		console.log("ShipState.getObjectState: Not using cache.");
+		// if (this.objectCache[o.id] !== undefined) {
+			// let c = this.objectCache[o.id];
+			// if (c.thisStateVer === this.version
+				// /*&& c.baseStateVer === o.baseObject.baseStateVersion
+				// && c.refStateVer === o.referenceStateVersion*/) {
+				// console.log("ShipState.getObjectState: Using cache.");
+				// return c.state;
+			// }
+		// }
+		// console.log("ShipState.getObjectState: Not using cache.");
 
 		let state = {};
 		Object.assign(state, o.baseObject.baseState);
@@ -78,12 +78,12 @@ Object.assign(ShipState.prototype, {
 			}
 		}
 
-		this.objectCache[o.id] = {
-			thisStateVer: this.version,
-			/*baseStateVer: o.baseObject.baseStateVersion,
-			refStateVer: o.referenceStateVersion,*/
-			state: state
-		};
+		// this.objectCache[o.id] = {
+			// thisStateVer: this.version,
+			// /*baseStateVer: o.baseObject.baseStateVersion,
+			// refStateVer: o.referenceStateVersion,*/
+			// state: state
+		// };
 
 		return state;
 	},
@@ -125,7 +125,7 @@ Object.assign(ShipState.prototype, {
 		oo.derivedByGroup = soo.derivedByGroup || {};
 		oo.derivedByID = soo.derivedByID || {};
 
-		this.version++;
+		//this.version++;
 
 		return this;
 	},
@@ -150,7 +150,7 @@ Object.assign(ShipState.prototype, {
 			}
 		}
 
-		this.version++;
+		//this.version++;
 	},
 	//Applies only directives of spec that have a corresponding directive in this.
 	override: function(spec) {
@@ -191,6 +191,6 @@ Object.assign(ShipState.prototype, {
 			}
 		}
 
-		this.version++;
+		//this.version++;
 	}
 });


### PR DESCRIPTION
Context: #105

I suspect this will break apps that abuse the `objectCache` property, which was the case with Ícaro's work at a time. @icarofonseca must look into this before merging.